### PR TITLE
feat(search): Add genre parameter to search_media

### DIFF
--- a/src/renfield_mcp_jellyfin/server.py
+++ b/src/renfield_mcp_jellyfin/server.py
@@ -124,28 +124,40 @@ mcp = FastMCP("renfield-jellyfin")
 
 @mcp.tool()
 async def search_media(
-    query: str,
+    query: str = "",
     type: str = "Audio",
     limit: int = 20,
+    genre: str = "",
 ) -> dict:
     """Search the Jellyfin media library.
 
     Args:
-        query: Search term (title, artist, album name)
+        query: Search term (title, artist, album name). Optional if genre is set.
         type: Item type — Audio, MusicAlbum, MusicArtist, Movie, or Series
         limit: Max results (1-50, default 20)
+        genre: Filter by genre name (e.g. "Pop", "Rock"). Can be combined with query.
     """
     if err := _check_config():
         return err
 
+    if not query and not genre:
+        return {"error": "Either query or genre (or both) must be provided."}
+
     limit = max(1, min(limit, 50))
+    params: dict[str, str | int] = {
+        "IncludeItemTypes": type,
+        "Recursive": "true",
+        "Limit": limit,
+        "Fields": "Genres,Artists,AlbumArtist,Album,ProductionYear,RunTimeTicks",
+    }
+    if query:
+        params["searchTerm"] = query
+    if genre:
+        params["Genres"] = genre
+
     data = await _jellyfin_get(
         f"/Users/{JELLYFIN_USER_ID}/Items",
-        searchTerm=query,
-        IncludeItemTypes=type,
-        Recursive="true",
-        Limit=limit,
-        Fields="Genres,Artists,AlbumArtist,Album,ProductionYear,RunTimeTicks",
+        **params,
     )
     field_map = {
         "Audio": ["id", "name", "artist", "album", "year", "duration", "api_stream", "image_url"],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -154,6 +154,34 @@ class TestSearchMedia:
             call_kwargs = mock.call_args
             assert call_kwargs.kwargs["Limit"] == 50
 
+    async def test_genre_filter(self):
+        with _patch_get({
+            "TotalRecordCount": 275,
+            "Items": [
+                {"Id": "a1", "Name": "Pop Album", "AlbumArtist": "Pop Artist", "ProductionYear": 2023, "Genres": ["Pop"]},
+            ],
+        }) as mock:
+            result = await jf.search_media(genre="Pop", type="MusicAlbum")
+            assert result["total"] == 275
+            assert mock.call_args.kwargs["Genres"] == "Pop"
+            assert "searchTerm" not in mock.call_args.kwargs
+
+    async def test_genre_and_query_combined(self):
+        with _patch_get({
+            "TotalRecordCount": 1,
+            "Items": [
+                {"Id": "a1", "Name": "Afterburner", "AlbumArtist": "ZZ Top", "ProductionYear": 1985, "Genres": ["Rock"]},
+            ],
+        }) as mock:
+            result = await jf.search_media(query="Afterburner", genre="Rock", type="MusicAlbum")
+            assert result["total"] == 1
+            assert mock.call_args.kwargs["searchTerm"] == "Afterburner"
+            assert mock.call_args.kwargs["Genres"] == "Rock"
+
+    async def test_no_query_no_genre_returns_error(self):
+        result = await jf.search_media()
+        assert "error" in result
+
     async def test_missing_config(self, monkeypatch):
         monkeypatch.setattr(jf, "JELLYFIN_URL", "")
         result = await jf.search_media("test")


### PR DESCRIPTION
## Summary
- `search_media` now accepts an optional `genre` parameter that maps to Jellyfin's `Genres` API filter
- `query` is now optional when `genre` is set — enables pure genre browsing
- Both parameters can be combined for filtered title searches
- Returns error when neither `query` nor `genre` is provided

Closes ebongard/renfield#235

## Test plan
- [x] `search_media(genre="Pop", type="MusicAlbum")` → passes `Genres=Pop`, no `searchTerm`
- [x] `search_media(query="Afterburner", genre="Rock")` → both params sent
- [x] `search_media()` with no args → returns error
- [x] All 43 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)